### PR TITLE
Fix initial InputField text setting.

### DIFF
--- a/ui/widgets/fields/input_field.cpp
+++ b/ui/widgets/fields/input_field.cpp
@@ -1341,8 +1341,8 @@ InputField::InputField(
 	setCursor(style::cur_text);
 	heightAutoupdated();
 
-	if (!_lastTextWithTags.text.isEmpty()) {
-		setTextWithTags(_lastTextWithTags, HistoryAction::Clear);
+	if (!value.text.isEmpty()) {
+		setTextWithTags(value, HistoryAction::Clear);
 	}
 
 	startBorderAnimation();


### PR DESCRIPTION
After stargin to merge block format to current cursor the _lastTextWithTags was cleared before being set from the same reference.